### PR TITLE
feat: add favicon and OpenGraph meta tags for SEO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -118,7 +118,11 @@
 
 ## Quick Wins (Optional)
 
-- [ ] Add favicon and OpenGraph meta tags for better SEO/sharing
+- [x] Add favicon and OpenGraph meta tags for better SEO/sharing
+  - *Completed: Created gift-themed SVG favicon (`apps/web/src/app/icon.svg`)*
+  - *Created dynamic OpenGraph image with Next.js ImageResponse API (`apps/web/src/app/opengraph-image.tsx`)*
+  - *Added comprehensive metadata in layout.tsx: title template, description, keywords, OpenGraph, Twitter cards, robots*
+  - *Metadata includes: site name, locale, card type, SEO keywords*
 - [x] Add "Copy to clipboard" button for group codes
   - *Completed: Added copy button in settings page with toast confirmation*
 - [ ] Mobile responsiveness polish on dashboard and results pages

--- a/apps/web/src/app/icon.svg
+++ b/apps/web/src/app/icon.svg
@@ -1,0 +1,26 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Gift box body -->
+  <rect x="4" y="13" width="24" height="16" rx="2" fill="#ff7eba" stroke="#15131c" stroke-width="1.5"/>
+
+  <!-- Gift box lid -->
+  <rect x="2" y="9" width="28" height="6" rx="1.5" fill="#f9df57" stroke="#15131c" stroke-width="1.5"/>
+
+  <!-- Vertical ribbon -->
+  <rect x="14" y="9" width="4" height="20" fill="#39b16c" stroke="#15131c" stroke-width="1"/>
+
+  <!-- Horizontal ribbon -->
+  <rect x="4" y="14" width="24" height="4" fill="#39b16c" stroke="#15131c" stroke-width="1"/>
+
+  <!-- Bow center -->
+  <circle cx="16" cy="7" r="3" fill="#6caade" stroke="#15131c" stroke-width="1"/>
+
+  <!-- Bow left loop -->
+  <ellipse cx="10" cy="6" rx="4" ry="3" fill="#6caade" stroke="#15131c" stroke-width="1"/>
+
+  <!-- Bow right loop -->
+  <ellipse cx="22" cy="6" rx="4" ry="3" fill="#6caade" stroke="#15131c" stroke-width="1"/>
+
+  <!-- Bow ribbons hanging -->
+  <path d="M13 9 L11 13 L13 11" fill="#6caade" stroke="#15131c" stroke-width="0.75"/>
+  <path d="M19 9 L21 13 L19 11" fill="#6caade" stroke="#15131c" stroke-width="0.75"/>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -28,8 +28,50 @@ const mrsPickles = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Pareto Presents",
-  description: "Helping you and your friends gift give (more optimally)",
+  title: {
+    default: "Pareto Presents - Smart Gift Exchange Matching",
+    template: "%s | Pareto Presents",
+  },
+  description:
+    "Algorithmic gift exchange matching for Secret Santa and White Elephant. Use smart algorithms to match givers with receivers based on preferences, interests, and compatibility.",
+  keywords: [
+    "gift exchange",
+    "secret santa",
+    "white elephant",
+    "gift matching",
+    "algorithm",
+    "pareto",
+    "holiday",
+    "gift giving",
+    "matching algorithm",
+    "hungarian algorithm",
+  ],
+  authors: [{ name: "Pareto Presents" }],
+  creator: "Pareto Presents",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL || "https://p-resents.vercel.app"
+  ),
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "Pareto Presents",
+    title: "Pareto Presents - Smart Gift Exchange Matching",
+    description:
+      "Algorithmic gift exchange matching for Secret Santa and White Elephant. Use smart algorithms to match givers with receivers based on preferences and interests.",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Pareto Presents - Smart Gift Exchange Matching",
+    description:
+      "Algorithmic gift exchange matching for Secret Santa and White Elephant.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  icons: {
+    icon: "/icon.svg",
+  },
 };
 
 export default function RootLayout({

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,0 +1,143 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+
+export const alt = 'Pareto Presents - Smart Gift Exchange Matching';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = 'image/png';
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#15131c',
+          padding: '40px',
+        }}
+      >
+        {/* Gift box icon */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginBottom: '30px',
+          }}
+        >
+          <svg width="120" height="120" viewBox="0 0 32 32" fill="none">
+            <rect x="4" y="13" width="24" height="16" rx="2" fill="#ff7eba" stroke="#f6f1ee" strokeWidth="1.5"/>
+            <rect x="2" y="9" width="28" height="6" rx="1.5" fill="#f9df57" stroke="#f6f1ee" strokeWidth="1.5"/>
+            <rect x="14" y="9" width="4" height="20" fill="#39b16c" stroke="#f6f1ee" strokeWidth="1"/>
+            <rect x="4" y="14" width="24" height="4" fill="#39b16c" stroke="#f6f1ee" strokeWidth="1"/>
+            <circle cx="16" cy="7" r="3" fill="#6caade" stroke="#f6f1ee" strokeWidth="1"/>
+            <ellipse cx="10" cy="6" rx="4" ry="3" fill="#6caade" stroke="#f6f1ee" strokeWidth="1"/>
+            <ellipse cx="22" cy="6" rx="4" ry="3" fill="#6caade" stroke="#f6f1ee" strokeWidth="1"/>
+          </svg>
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <h1
+            style={{
+              fontSize: '72px',
+              fontWeight: 'bold',
+              background: 'linear-gradient(90deg, #ff7eba, #f9df57, #ff9c42, #39b16c, #6caade)',
+              backgroundClip: 'text',
+              color: 'transparent',
+              margin: '0 0 20px 0',
+              textAlign: 'center',
+            }}
+          >
+            Pareto Presents
+          </h1>
+          <p
+            style={{
+              fontSize: '32px',
+              color: '#f6f1ee',
+              margin: '0',
+              textAlign: 'center',
+              opacity: 0.9,
+            }}
+          >
+            Smart Gift Exchange Matching
+          </p>
+          <p
+            style={{
+              fontSize: '24px',
+              color: '#f6f1ee',
+              margin: '20px 0 0 0',
+              textAlign: 'center',
+              opacity: 0.7,
+            }}
+          >
+            Algorithmic matching for Secret Santa & White Elephant
+          </p>
+        </div>
+
+        {/* Feature pills */}
+        <div
+          style={{
+            display: 'flex',
+            gap: '20px',
+            marginTop: '40px',
+          }}
+        >
+          <div
+            style={{
+              padding: '12px 24px',
+              backgroundColor: '#ff7eba',
+              borderRadius: '20px',
+              color: '#15131c',
+              fontSize: '20px',
+              fontWeight: 600,
+            }}
+          >
+            Max Utility
+          </div>
+          <div
+            style={{
+              padding: '12px 24px',
+              backgroundColor: '#f9df57',
+              borderRadius: '20px',
+              color: '#15131c',
+              fontSize: '20px',
+              fontWeight: 600,
+            }}
+          >
+            Max Fairness
+          </div>
+          <div
+            style={{
+              padding: '12px 24px',
+              backgroundColor: '#39b16c',
+              borderRadius: '20px',
+              color: '#f6f1ee',
+              fontSize: '20px',
+              fontWeight: 600,
+            }}
+          >
+            White Elephant
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- Add gift-themed SVG favicon matching app's colorful aesthetic
- Create dynamic OpenGraph image using Next.js ImageResponse API for social sharing
- Expand layout metadata with comprehensive SEO tags (title template, keywords, OpenGraph, Twitter cards)

## Test plan
- [ ] Verify favicon appears in browser tab
- [ ] Test OpenGraph image preview using https://www.opengraph.xyz/
- [ ] Check Twitter card preview using Twitter Card Validator
- [ ] Verify meta tags render correctly in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)